### PR TITLE
Fix skill-gold color defining in @theme block in global.css

### DIFF
--- a/global.css
+++ b/global.css
@@ -16,7 +16,7 @@
   /* SKILL DOMAIN COLORS */
   --color-skill-blue: #5b8def; /* Programming / STEM */
   --color-skill-violet: #b97cf3; /* Music / Arts */
-  -color-skill-gold: var(--color-ambition-gold); /* Content Creation */
+  --color-skill-gold: var(--color-ambition-gold); /* Content Creation */
   --color-skill-teal: #3ecfb2; /* Business / Entrepreneurship */
   --color-skill-coral: #f7956b; /* Communication / Leadership */
   --color-skill-sage: var(--color-sage); /* Academics / Learning */


### PR DESCRIPTION
This pull request fixes a minor typo in the `global.css` file. The change corrects the syntax for the `--color-skill-gold` CSS variable by adding a missing leading dash.

- Fixed a typo in the `--color-skill-gold` CSS variable definition to ensure proper variable declaration.