### PR TITLE
Add skills screen and skill card UI

### DIFF
--- a/app/(tabs)/SkillsScreen.tsx
+++ b/app/(tabs)/SkillsScreen.tsx
@@ -1,11 +1,9 @@
-import { Ionicons } from "@expo/vector-icons";
 import React from "react";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import SkillCard from "../components/SkillCard";
 
 const SkillsScreen = () => {
-  const programmingLevel = (1000 / 1000) * 100;
-
   return (
     <View className="flex-1 bg-bg px-6 py-4">
       <SafeAreaView>
@@ -16,28 +14,7 @@ const SkillsScreen = () => {
 
         {/* CONTENT */}
         <View className="mt-6">
-          {/* SKILL CARD */}
-          <View className="flex-row items-center bg-card rounded-lg shadow-sm elevation-md px-6 py-4 transition-all duration-300 ease-in-out active:scale-[0.95] active:opacity-85">
-            <View className="bg-warm-paper/20 p-1.5 rounded-sm">
-              <Ionicons name="code" size={16} color="#f5f2ec" />
-            </View>
-
-            <View className="ml-4">
-              <Text className="text-text">Programming</Text>
-
-              <View className="h-2 bg-warm-paper/20 w-48 mt-2 rounded-full overflow-hidden">
-                <View
-                  className={`h-2 bg-skill-blue w-[${programmingLevel}%]`}
-                />
-              </View>
-            </View>
-
-            <View className="ml-auto">
-              <Text className="text-text">
-                {Math.min(programmingLevel, 100).toFixed(0)} / 100
-              </Text>
-            </View>
-          </View>
+          <SkillCard skillName="Programming" skillLevel={1} skillIcon="code" />
         </View>
       </SafeAreaView>
     </View>

--- a/app/(tabs)/SkillsScreen.tsx
+++ b/app/(tabs)/SkillsScreen.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 const SkillsScreen = () => {
   return (
-    <View>
-      <Text>SkillsScreen</Text>
+    <View className="flex-1 bg-bg px-6 py-4">
+      <SafeAreaView>
+        {/* HEADER */}
+        <Text className="text-text text-center text-lg font-semibold">
+          Skills
+        </Text>
+      </SafeAreaView>
     </View>
   );
 };

--- a/app/(tabs)/SkillsScreen.tsx
+++ b/app/(tabs)/SkillsScreen.tsx
@@ -1,8 +1,11 @@
+import { Ionicons } from "@expo/vector-icons";
 import React from "react";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 const SkillsScreen = () => {
+  const programmingLevel = (1000 / 1000) * 100;
+
   return (
     <View className="flex-1 bg-bg px-6 py-4">
       <SafeAreaView>
@@ -10,6 +13,32 @@ const SkillsScreen = () => {
         <Text className="text-text text-center text-lg font-semibold">
           Skills
         </Text>
+
+        {/* CONTENT */}
+        <View className="mt-6">
+          {/* SKILL CARD */}
+          <View className="flex-row items-center bg-card rounded-lg shadow-sm elevation-md px-6 py-4 transition-all duration-300 ease-in-out active:scale-[0.95] active:opacity-85">
+            <View className="bg-warm-paper/20 p-1.5 rounded-sm">
+              <Ionicons name="code" size={16} color="#f5f2ec" />
+            </View>
+
+            <View className="ml-4">
+              <Text className="text-text">Programming</Text>
+
+              <View className="h-2 bg-warm-paper/20 w-48 mt-2 rounded-full overflow-hidden">
+                <View
+                  className={`h-2 bg-skill-blue w-[${programmingLevel}%]`}
+                />
+              </View>
+            </View>
+
+            <View className="ml-auto">
+              <Text className="text-text">
+                {Math.min(programmingLevel, 100).toFixed(0)} / 100
+              </Text>
+            </View>
+          </View>
+        </View>
       </SafeAreaView>
     </View>
   );

--- a/app/(tabs)/SkillsScreen.tsx
+++ b/app/(tabs)/SkillsScreen.tsx
@@ -14,30 +14,39 @@ const SkillsScreen = () => {
 
         {/* CONTENT */}
         <View className="mt-6 gap-6">
-          <SkillCard skillName="Programming" skillLevel={1} skillIcon="code" />
+          <SkillCard
+            skillName="Programming"
+            skillLevel={1}
+            skillIcon="code"
+            skillColor="#5b8def"
+          />
 
           <SkillCard
             skillName="Singing"
             skillLevel={24}
             skillIcon="musical-note-outline"
+            skillColor="#b97cf3"
           />
 
           <SkillCard
             skillName="Painting"
             skillLevel={50}
             skillIcon="brush-outline"
+            skillColor="#b97cf3"
           />
 
           <SkillCard
             skillName="Story Telling"
             skillLevel={10}
             skillIcon="book-outline"
+            skillColor="#f7956b"
           />
 
           <SkillCard
             skillName="Video Editing"
             skillLevel={22}
             skillIcon="videocam-outline"
+            skillColor="#f4c542"
           />
         </View>
       </SafeAreaView>

--- a/app/(tabs)/SkillsScreen.tsx
+++ b/app/(tabs)/SkillsScreen.tsx
@@ -13,8 +13,32 @@ const SkillsScreen = () => {
         </Text>
 
         {/* CONTENT */}
-        <View className="mt-6">
+        <View className="mt-6 gap-6">
           <SkillCard skillName="Programming" skillLevel={1} skillIcon="code" />
+
+          <SkillCard
+            skillName="Singing"
+            skillLevel={24}
+            skillIcon="musical-note-outline"
+          />
+
+          <SkillCard
+            skillName="Painting"
+            skillLevel={50}
+            skillIcon="brush-outline"
+          />
+
+          <SkillCard
+            skillName="Story Telling"
+            skillLevel={10}
+            skillIcon="book-outline"
+          />
+
+          <SkillCard
+            skillName="Video Editing"
+            skillLevel={22}
+            skillIcon="videocam-outline"
+          />
         </View>
       </SafeAreaView>
     </View>

--- a/app/components/SkillCard.tsx
+++ b/app/components/SkillCard.tsx
@@ -6,9 +6,15 @@ type SkillCardProps = {
   skillName: string;
   skillLevel: number;
   skillIcon: ComponentProps<typeof Ionicons>["name"];
+  skillColor: string;
 };
 
-const SkillCard = ({ skillName, skillLevel, skillIcon }: SkillCardProps) => {
+const SkillCard = ({
+  skillName,
+  skillLevel,
+  skillIcon,
+  skillColor,
+}: SkillCardProps) => {
   return (
     <View className="flex-row items-center bg-card rounded-lg shadow-sm elevation-md px-6 py-4 transition-all duration-300 ease-in-out active:scale-[0.95] active:opacity-85">
       <View className="bg-warm-paper/20 p-1.5 rounded-sm">
@@ -22,7 +28,7 @@ const SkillCard = ({ skillName, skillLevel, skillIcon }: SkillCardProps) => {
           <View
             style={{
               height: 8,
-              backgroundColor: "#5b8def",
+              backgroundColor: skillColor,
               width: `${skillLevel}%`,
             }}
           />

--- a/app/components/SkillCard.tsx
+++ b/app/components/SkillCard.tsx
@@ -19,7 +19,13 @@ const SkillCard = ({ skillName, skillLevel, skillIcon }: SkillCardProps) => {
         <Text className="text-text">{skillName}</Text>
 
         <View className="h-2 bg-warm-paper/20 w-48 mt-2 rounded-full overflow-hidden">
-          <View className={`h-2 bg-skill-blue w-[${skillLevel}%]`} />
+          <View
+            style={{
+              height: 8,
+              backgroundColor: "#5b8def",
+              width: `${skillLevel}%`,
+            }}
+          />
         </View>
       </View>
 

--- a/app/components/SkillCard.tsx
+++ b/app/components/SkillCard.tsx
@@ -16,7 +16,7 @@ const SkillCard = ({
   skillColor,
 }: SkillCardProps) => {
   return (
-    <View className="flex-row items-center bg-card rounded-lg shadow-sm elevation-md px-6 py-4 transition-all duration-300 ease-in-out active:scale-[0.95] active:opacity-85">
+    <View className="w-full flex-row items-center bg-card rounded-lg shadow-sm elevation-md px-6 py-4 transition-all duration-300 ease-in-out active:scale-[0.95] active:opacity-85">
       <View className="bg-warm-paper/20 p-1.5 rounded-sm">
         <Ionicons name={skillIcon} size={16} color="#f5f2ec" />
       </View>
@@ -24,7 +24,7 @@ const SkillCard = ({
       <View className="ml-4">
         <Text className="text-text">{skillName}</Text>
 
-        <View className="h-2 bg-warm-paper/20 w-48 mt-2 rounded-full overflow-hidden">
+        <View className="h-2 bg-warm-paper/20 w-full mt-2 rounded-full overflow-hidden">
           <View
             style={{
               height: 8,

--- a/app/components/SkillCard.tsx
+++ b/app/components/SkillCard.tsx
@@ -1,0 +1,35 @@
+import { Ionicons } from "@expo/vector-icons";
+import React, { ComponentProps } from "react";
+import { Text, View } from "react-native";
+
+type SkillCardProps = {
+  skillName: string;
+  skillLevel: number;
+  skillIcon: ComponentProps<typeof Ionicons>["name"];
+};
+
+const SkillCard = ({ skillName, skillLevel, skillIcon }: SkillCardProps) => {
+  return (
+    <View className="flex-row items-center bg-card rounded-lg shadow-sm elevation-md px-6 py-4 transition-all duration-300 ease-in-out active:scale-[0.95] active:opacity-85">
+      <View className="bg-warm-paper/20 p-1.5 rounded-sm">
+        <Ionicons name={skillIcon} size={16} color="#f5f2ec" />
+      </View>
+
+      <View className="ml-4">
+        <Text className="text-text">{skillName}</Text>
+
+        <View className="h-2 bg-warm-paper/20 w-48 mt-2 rounded-full overflow-hidden">
+          <View className={`h-2 bg-skill-blue w-[${skillLevel}%]`} />
+        </View>
+      </View>
+
+      <View className="ml-auto">
+        <Text className="text-text">
+          {Math.min(skillLevel, 100).toFixed(0)} / 100
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+export default SkillCard;


### PR DESCRIPTION
This pull request adds a new `SkillCard` component and updates the `SkillsScreen` to display a list of skill cards with improved layout and styling. The changes enhance the UI by making the skills screen more visually appealing and modular.

**UI Enhancements and Componentization:**

* Created a new reusable `SkillCard` component in `app/components/SkillCard.tsx` to display individual skill information, including skill name, level, icon, and a progress bar.
* Updated `SkillsScreen` in `app/(tabs)/SkillsScreen.tsx` to use the new `SkillCard` component for each skill, and improved the overall layout with better spacing, header, and safe area handling.